### PR TITLE
Migrate code to Go 1.26 features (ReverseProxy Rewrite, Benchmark Loop)

### DIFF
--- a/pkg/cache/pebble/pebble_test.go
+++ b/pkg/cache/pebble/pebble_test.go
@@ -366,7 +366,7 @@ func BenchmarkPebble(b *testing.B) {
 			}
 		}
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			err := c.Range(func(key []byte, value []byte) bool {
 				return true
 			})

--- a/pkg/net/proxy/yuubinsya/uot_test.go
+++ b/pkg/net/proxy/yuubinsya/uot_test.go
@@ -64,7 +64,7 @@ func BenchmarkUoT_Throughput(b *testing.B) {
 				b.SetBytes(int64(size))
 				b.ResetTimer()
 
-				for i := 0; i < b.N; i++ {
+				for b.Loop() {
 					if _, err := pc.WriteTo(payload, addr); err != nil {
 						b.Fatal(err)
 					}
@@ -120,7 +120,7 @@ func BenchmarkUoT_Latency(b *testing.B) {
 
 			b.ResetTimer()
 
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				if _, err := pc.WriteTo(payload, addr); err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/net/trie/v2/domain/badger_test.go
+++ b/pkg/net/trie/v2/domain/badger_test.go
@@ -215,8 +215,8 @@ func BenchmarkDiskTrie(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			dt.Insert(newFqdnReader(domains[i]), "BenchmarkValue")
+		for i := 0; b.Loop(); i++ {
+			dt.Insert(newFqdnReader(domains[i%len(domains)]), "BenchmarkValue")
 		}
 	})
 
@@ -254,7 +254,7 @@ func BenchmarkDiskTrie(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			dt.Search(newFqdnReader(randomDomainParts(5)))
 		}
 	})

--- a/pkg/net/trie/v2/domain/pebble_test.go
+++ b/pkg/net/trie/v2/domain/pebble_test.go
@@ -216,8 +216,8 @@ func BenchmarkDiskPebbleTrie(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			dt.Insert(newFqdnReader(domains[i]), "BenchmarkValue")
+		for i := 0; b.Loop(); i++ {
+			dt.Insert(newFqdnReader(domains[i%len(domains)]), "BenchmarkValue")
 		}
 	})
 
@@ -255,7 +255,7 @@ func BenchmarkDiskPebbleTrie(b *testing.B) {
 		}
 
 		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
+		for b.Loop() {
 			dt.Search(newFqdnReader(randomDomainParts(5)))
 		}
 	})

--- a/pkg/statistics/cache_test.go
+++ b/pkg/statistics/cache_test.go
@@ -40,7 +40,7 @@ func BenchmarkCache(b *testing.B) {
 	})
 	defer cc.Close()
 
-	for i := range b.N {
+	for i := 0; b.Loop(); i++ {
 		cc.AddDownload(uint64(i))
 	}
 }


### PR DESCRIPTION
Migrated `httputil.ReverseProxy` from `Director` to `Rewrite` in `pkg/net/proxy/reverse/unwrap.go`.
Updated benchmarks in `pkg/statistics`, `pkg/cache/pebble`, `pkg/net/proxy/yuubinsya`, and `pkg/net/trie/v2/domain` to use `b.Loop()`.
Verified changes with `go test` and `go test -bench`.

---
*PR created automatically by Jules for task [12227607538879683936](https://jules.google.com/task/12227607538879683936) started by @Asutorufa*